### PR TITLE
fix: remove jq library entries from monitoring files

### DIFF
--- a/monitoring/nodejs-tools/package.json
+++ b/monitoring/nodejs-tools/package.json
@@ -8,7 +8,6 @@
     "docker": "20.10.21",
     "@kubernetes/kubectl": "1.25.4",
     "terraform": "1.3.0",
-    "jq": "1.6",
     "node": "24.6.0",
     "code": "1.85.1",
     "ollama": "0.1.17"

--- a/monitoring/python-tools/requirements.txt
+++ b/monitoring/python-tools/requirements.txt
@@ -13,9 +13,6 @@ kubectl==1.25.4
 # terraform - https://github.com/hashicorp/terraform
 terraform==1.3.0
 
-# jq - https://github.com/jqlang/jq
-jq==1.6
-
 # node - https://github.com/nodejs/node
 node==18.19.0
 


### PR DESCRIPTION
- Remove jq library from monitoring/nodejs-tools/package.json
- Remove jq library from monitoring/python-tools/requirements.txt
- Resolves confusion between jq command-line tool and jq libraries
- Prevents Dependabot from creating irrelevant library update PRs

Only the command-line jq tool (jqlang/jq) should be monitored via tools.yaml. This cleanup ensures proper separation between binary tools and language libraries.

Fixes #16

🤖 Generated with [Claude Code](https://claude.ai/code)